### PR TITLE
Fix Crowdin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ApkShellext2![logo](https://github.com/kkguo/apkshellext/blob/ApkShellext2/ApkShellext2/Resources/Apkshellext_icons/apkshell_b64.png?raw=true)  
-[![Crowdin](https://d322cqt584bo4o.cloudfront.net/apkshellext/localized.svg)](http://translate.apkshellext.com/project/apkshellext)
+[![Crowdin](https://d322cqt584bo4o.cloudfront.net/apkshellext/localized.svg)](http://translate.apkshellext.com/)
 
 A Windows shell extension supporting icon for files of
 * .apk (android package)


### PR DESCRIPTION
I fixed the translate button link because [translate.apkshellext.com](http://translate.apkshellext.com/) already redirects to [crowdin.com/project/apkshellext](https://crowdin.com/project/apkshellext)